### PR TITLE
Fix particle background animation freeze on resize

### DIFF
--- a/js/three-scene.js
+++ b/js/three-scene.js
@@ -17,7 +17,7 @@
   
   // Mobile detection
   const isMobile = window.innerWidth < 768;
-  const particleCount = isMobile ? 100 : 300;
+  let particleCount = isMobile ? 100 : 300;
 
   // Scene setup
   const canvas = document.getElementById('three-canvas');
@@ -145,8 +145,11 @@
     if (Math.abs(newParticleCount - particleCount) > 50) {
       if (particles) {
         scene.remove(particles);
+        particles.geometry.dispose();
+        particles.material.dispose();
         particles = null;
       }
+      particleCount = newParticleCount;
       initHeroParticles();
     }
   }


### PR DESCRIPTION
Fixes an issue where resizing the browser causes the particle background animation to stop moving. Update memory handling to prevent WebGL memory leaks during scene resets.

---
*PR created automatically by Jules for task [4180589192254717019](https://jules.google.com/task/4180589192254717019) started by @aejontargaryen*