### PR TITLE
Fix Safari particle freeze and enhance UI/effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,17 +374,8 @@
                                         stroke-linecap="round"
                                         stroke-linejoin="round"
                                     >
-                                        <rect
-                                            x="3"
-                                            y="4"
-                                            width="18"
-                                            height="18"
-                                            rx="2"
-                                            ry="2"
-                                        />
-                                        <line x1="16" y1="2" x2="16" y2="6" />
-                                        <line x1="8" y1="2" x2="8" y2="6" />
-                                        <line x1="3" y1="10" x2="21" y2="10" />
+                                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                                     </svg>
                                 </div>
                                 <h3>Certificates Of Deposit</h3>
@@ -827,6 +818,10 @@
                     )
                         return;
                     transitioning = true;
+
+                    // Optional frame spin effect
+                    document.body.classList.add("spin-transition");
+                    setTimeout(() => document.body.classList.remove("spin-transition"), cooldown);
 
                     sections[current].classList.remove("active");
                     sections[index].classList.add("active");

--- a/js/three-scene.js
+++ b/js/three-scene.js
@@ -13,11 +13,15 @@
   }
 
   // Check for reduced motion preference
-  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let reduceMotion = false;
+  if (typeof window.matchMedia === 'function') {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reduceMotion = mediaQuery && mediaQuery.matches;
+  }
   
   // Mobile detection
   const isMobile = window.innerWidth < 768;
-  let particleCount = isMobile ? 100 : 300;
+  let particleCount = isMobile ? 80 : 250;
 
   // Scene setup
   const canvas = document.getElementById('three-canvas');
@@ -45,11 +49,11 @@
       positions[i * 3 + 1] = (Math.random() - 0.5) * 12 - 2;
       positions[i * 3 + 2] = (Math.random() - 0.5) * 8 - 2;
       
-      velocities[i * 3] = (Math.random() - 0.5) * 0.01;
-      velocities[i * 3 + 1] = Math.random() * 0.03 + 0.01;
-      velocities[i * 3 + 2] = (Math.random() - 0.5) * 0.01;
+      velocities[i * 3] = (Math.random() - 0.5) * 0.015;
+      velocities[i * 3 + 1] = Math.random() * 0.04 + 0.02;
+      velocities[i * 3 + 2] = (Math.random() - 0.5) * 0.015;
       
-      sizes[i] = Math.random() * 0.1 + 0.01;
+      sizes[i] = Math.random() * 0.08 + 0.02;
     }
     
     geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
@@ -91,19 +95,25 @@
     
     time += 0.01;
     
-    if (particles && !reduceMotion) {
+    if (particles) {
       const positions = particles.geometry.attributes.position.array;
       const velocities = particles.userData.velocities;
+      const speedMultiplier = reduceMotion ? 0.1 : 1.0;
       
       for (let i = 0; i < particleCount; i++) {
-        // Wind effect: add subtle horizontal oscillation
-        positions[i * 3] += velocities[i * 3] + Math.sin(time + i) * 0.002;
-        positions[i * 3 + 1] += velocities[i * 3 + 1];
-        positions[i * 3 + 2] += velocities[i * 3 + 2] + Math.cos(time + i) * 0.002;
+        // Wind effect: chaotic horizontal and depth oscillation for embers
+        const windX = Math.sin(time * 2 + i) * 0.003 + Math.sin(time * 0.5 + i * 2) * 0.002;
+        const windZ = Math.cos(time * 2 + i) * 0.003 + Math.cos(time * 0.5 + i * 2) * 0.002;
+
+        positions[i * 3] += (velocities[i * 3] + windX) * speedMultiplier;
+        positions[i * 3 + 1] += velocities[i * 3 + 1] * speedMultiplier;
+        positions[i * 3 + 2] += (velocities[i * 3 + 2] + windZ) * speedMultiplier;
         
-        // "Pop" effect: occasional sudden upward boost
-        if (Math.random() < 0.005) {
-          positions[i * 3 + 1] += Math.random() * 0.1;
+        // "Pop" effect: occasional sudden upward and sideways boost (like popping ember)
+        if (!reduceMotion && Math.random() < 0.002) {
+          positions[i * 3] += (Math.random() - 0.5) * 0.2;
+          positions[i * 3 + 1] += Math.random() * 0.15;
+          positions[i * 3 + 2] += (Math.random() - 0.5) * 0.2;
         }
         
         // Reset if out of view
@@ -117,7 +127,9 @@
       particles.geometry.attributes.position.needsUpdate = true;
       
       // Subtle rotation
-      particles.rotation.y = Math.sin(time * 0.1) * 0.05;
+      if (!reduceMotion) {
+        particles.rotation.y = Math.sin(time * 0.2) * 0.08;
+      }
     }
     
     // Smooth parallax
@@ -134,7 +146,7 @@
 
   // Handle resize
   function onResize() {
-    const newParticleCount = window.innerWidth < 768 ? 100 : 300;
+    const newParticleCount = window.innerWidth < 768 ? 80 : 250;
     
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();

--- a/style.css
+++ b/style.css
@@ -1474,3 +1474,18 @@ footer {
     background: var(--fire);
     color: var(--black);
 }
+
+/* --- SPIN TRANSITION --- */
+.spin-transition {
+    animation: fadeSpin 0.7s var(--ease) forwards;
+}
+
+@keyframes fadeSpin {
+    0% { transform: scale(1) rotate(0deg); opacity: 1; }
+    50% { transform: scale(0.95) rotate(2deg); opacity: 0.8; }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .spin-transition { animation: none; }
+}


### PR DESCRIPTION
- Safely handle `prefers-reduced-motion` in macOS Safari so particles gracefully slow down instead of completely stopping.
- Refined particle physics to mimic realistic fire embers: added chaotic wind movements, slightly increased upward velocity, and reduced particle counts (250 desktop / 80 mobile).
- Replaced the "Certificates of Deposit" icon with a new shield lock icon.
- Added a `spin-transition` effect to the page transition `goTo` logic and defined the CSS `@keyframes fadeSpin` for the frame spin effect.

---
*PR created automatically by Jules for task [14319043470851597977](https://jules.google.com/task/14319043470851597977) started by @aejontargaryen*